### PR TITLE
Re-add asyncpg as requirement (until v1.1.0) to prevent breaking anyone's setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ service is generally small.
 
 ## Getting started
 ### Install `migri`
-Run `pip install migri`
+Run `pip install migri[postgresql]`
 
 ### Create migrations
 Create a `migrations` directory and add your migrations. Migrations are applied in 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         # "sqlite": ["aiosqlite"],  TODO enable when ready
     },
     install_requires=[
+        "asyncpg",
         "click==7.*",
         "sqlparse==0.3.*",
     ],


### PR DESCRIPTION
Packages/projects that depend on migri (latest) would've broken because `pip install migri[postgresql]` would've been required...or installing `asyncpg` explicitly.